### PR TITLE
Support for async chksum calculation

### DIFF
--- a/.cargo/README.md
+++ b/.cargo/README.md
@@ -25,6 +25,14 @@ Alternatively, you can use the [`cargo add`](https://doc.rust-lang.org/cargo/com
 cargo add chksum-core
 ```
 
+## Features
+
+### Asynchronous Runtime
+
+* `async-runtime-tokio`: Enables async interface for Tokio runtime.
+
+By default, neither of these features is enabled.
+
 ## Example Crates
 
 For implementation-specific examples, refer to the source code of the following crates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added async support for Tokio runtime.
+- Added `doc_auto_cfg` feature.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added async support for Tokio runtime.
+
 ### Fixed
 
 - Added missing method comments to improve documentation clarity.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,13 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+async-trait = { version = "0.1.80", optional = true }
 chksum-hash-core = "0.0.0"
 thiserror = "1.0.51"
+tokio = { version = "1.37.0", features = ["fs", "io-util", "io-std"], optional = true }
+
+[features]
+default = []
+
+# async runtimes
+async-runtime-tokio = ["async-trait", "tokio"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Alternatively, you can use the [`cargo add`](https://doc.rust-lang.org/cargo/com
 cargo add chksum-core
 ```
 
+## Features
+
+### Asynchronous Runtime
+
+* `async-runtime-tokio`: Enables async interface for Tokio runtime.
+
+By default, neither of these features is enabled.
+
 ## Example Crates
 
 For implementation-specific examples, refer to the source code of the following crates:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //!
 //! This crate is licensed under the MIT License.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 
 mod error;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,0 +1,117 @@
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use tokio::fs::{metadata, read_dir, DirEntry, File, ReadDir};
+use tokio::io::{AsyncBufReadExt as _, BufReader, Stdin};
+
+use crate::{AsyncChksumable, Hash, Hashable, Result};
+
+macro_rules! impl_async_chksumable {
+    ($($t:ty),+ => $i:tt) => {
+        $(
+            #[async_trait]
+            impl AsyncChksumable for $t $i
+        )*
+    };
+}
+
+impl_async_chksumable!(Path, &Path, &mut Path => {
+    async fn chksum_with<H>(&mut self, hash: &mut H) -> Result<()>
+    where
+        H: Hash + Send,
+    {
+        let metadata = metadata(&self).await?;
+        if metadata.is_dir() {
+            read_dir(self).await?.chksum_with(hash).await
+        } else {
+            // everything treat as a file when it is not a directory
+            File::open(self).await?.chksum_with(hash).await
+        }
+    }
+
+});
+
+impl_async_chksumable!(PathBuf, &PathBuf, &mut PathBuf => {
+    async fn chksum_with<H>(&mut self, hash: &mut H) -> Result<()>
+    where
+        H: Hash + Send,
+    {
+        self.as_path().chksum_with(hash).await
+    }
+});
+
+// TODO: missing `&File` implementation
+impl_async_chksumable!(File, &mut File => {
+    async fn chksum_with<H>(&mut self, hash: &mut H) -> Result<()>
+    where
+        H: Hash + Send,
+    {
+        // TODO: tracking issue [tokio-rs/tokio#6407](github.com/tokio-rs/tokio/issues/6407)
+        // if self.is_terminal() {
+        //     return Err(Error::IsTerminal);
+        // }
+
+        let mut reader = BufReader::new(self);
+        loop {
+            let buffer = reader.fill_buf().await?;
+            let length = buffer.len();
+            if length == 0 {
+                break;
+            }
+            buffer.hash_with(hash);
+            reader.consume(length);
+        }
+        Ok(())
+    }
+});
+
+impl_async_chksumable!(DirEntry, &DirEntry, &mut DirEntry => {
+    async fn chksum_with<H>(&mut self, hash: &mut H) -> Result<()>
+    where
+        H: Hash + Send,
+    {
+        self.path().chksum_with(hash).await
+    }
+});
+
+impl_async_chksumable!(ReadDir, &mut ReadDir => {
+    async fn chksum_with<H>(&mut self, hash: &mut H) -> Result<()>
+    where
+        H: Hash + Send,
+    {
+        let mut dir_entries = Vec::new();
+        while let Some(dir_entry) = self.next_entry().await? {
+            dir_entries.push(dir_entry);
+        }
+        dir_entries.sort_by_key(DirEntry::path);
+        for mut dir_entry in dir_entries {
+            dir_entry.chksum_with(hash).await?;
+        }
+        Ok(())
+    }
+});
+
+// TODO: missing `&Stdin` implementation
+impl_async_chksumable!(Stdin, &mut Stdin => {
+    async fn chksum_with<H>(&mut self, hash: &mut H) -> Result<()>
+    where
+        H: Hash + Send,
+    {
+        // TODO: tracking issue [tokio-rs/tokio#6407](github.com/tokio-rs/tokio/issues/6407)
+        // if self.is_terminal() {
+        //     return Err(Error::IsTerminal);
+        // }
+
+        let mut reader = BufReader::new(self);
+        loop {
+            let buffer = reader.fill_buf().await?;
+            let length = buffer.len();
+            if length == 0 {
+                break;
+            }
+            buffer.hash_with(hash);
+            reader.consume(length);
+        }
+        Ok(())
+    }
+});


### PR DESCRIPTION
This PR adds support for async chksum calculation.

Support for various runtimes:

- [ ] async-std
- [x] tokio
- [ ] ?

Work in progress. Related issue chksum-rs/lib#1.